### PR TITLE
Fix for #12

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -13,9 +13,9 @@ Use the **same version** for the git tag as in the properties file.
 - Via git tag
     1. Create a new version tag.
        ```bash
-       git tag [MAJOR].[MINOR].[PATCH]
+       git tag v[MAJOR].[MINOR].[PATCH]
        ```
-       > Example: `git tag 2.5.5`
+       > Example: `git tag v2.5.5`
     2. Push the tag.
        ```bash
        git push origin --tags
@@ -27,9 +27,10 @@ Use the **same version** for the git tag as in the properties file.
 
 ## Sync
 
-1. Log in to [bintray.com](https://bintray.com/configcat/releases/configcat-java-client#central) and sync the new
-   package to Maven Central.
-2. Make sure the new version is available on [jcenter](https://bintray.com/configcat/releases/configcat-java-client).
+1. Log in to [Maven Repository](https://oss.sonatype.org/) and follow these steps:
+   1. Select `Staging Repositories` and select the version you published.
+   2. Click `Close`. The process might take some time, click `Refresh` to get the latest state.
+   3. When the repo is closed click `Release`, tick the `Automatically drop when released` option.
 2. Make sure the new version is available
    on [Maven Central](https://search.maven.org/artifact/com.configcat/configcat-java-client).
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=7.0.5
+version=7.0.6

--- a/src/main/java/com/configcat/ConfigJsonCache.java
+++ b/src/main/java/com/configcat/ConfigJsonCache.java
@@ -4,7 +4,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.DigestUtils;
-import java.time.Instant;
 
 class ConfigJsonCache {
     private static final String CACHE_BASE = "java_" + ConfigFetcher.CONFIG_JSON_NAME + "_%s";

--- a/src/main/java/com/configcat/ConfigJsonCache.java
+++ b/src/main/java/com/configcat/ConfigJsonCache.java
@@ -44,9 +44,6 @@ class ConfigJsonCache {
 
         try {
             Config config = this.deserialize(fromCache);
-            if (this.inMemoryConfig.timeStamp >= config.timeStamp) {
-                return this.inMemoryConfig;
-            }
             this.inMemoryConfig = config;
             this.inMemoryConfigString = fromCache;
             return config;
@@ -58,7 +55,6 @@ class ConfigJsonCache {
 
     public void writeToCache(Config config) {
         try {
-            config.timeStamp = Instant.now().getEpochSecond();
             String configToCache = this.gson.toJson(config);
             this.inMemoryConfig = config;
             this.inMemoryConfigString = configToCache;

--- a/src/main/java/com/configcat/ConfigModels.java
+++ b/src/main/java/com/configcat/ConfigModels.java
@@ -20,8 +20,6 @@ class Config {
     public Map<String, Setting> entries = new HashMap<>();
     @SerializedName(value = "e")
     public String eTag = "";
-    @SerializedName(value = "t")
-    public long timeStamp = -1;
 
     public static Config empty = new Config();
 }

--- a/src/test/java/com/configcat/ConfigCatClientIntegrationTest.java
+++ b/src/test/java/com/configcat/ConfigCatClientIntegrationTest.java
@@ -230,7 +230,7 @@ public class ConfigCatClientIntegrationTest {
         memoryCache.writeToCache(initialConfig);
 
         Config updated = memoryCache.readFromJson(String.format(TEST_JSON, "updated"), "etag2");
-        memoryCache.writeToCache(updated);
+        memoryCache.writeToCache(updated); // this will fail
 
         Config fromCache1 = memoryCache.readFromCache();
         assertEquals(initialConfig.eTag, fromCache1.eTag);

--- a/src/test/java/com/configcat/ConfigCatClientIntegrationTest.java
+++ b/src/test/java/com/configcat/ConfigCatClientIntegrationTest.java
@@ -23,7 +23,6 @@ public class ConfigCatClientIntegrationTest {
     private static final String APIKEY = "TEST_KEY";
     private ConfigCatClient client;
     private MockWebServer server;
-    private final ConfigCatLogger logger = new ConfigCatLogger(LoggerFactory.getLogger(ManualPollingPolicyTest.class));
 
     private static final String TEST_JSON = "{ f: { fakeKey: { v: %s, p: [] ,r: [] } } }";
 
@@ -224,7 +223,8 @@ public class ConfigCatClientIntegrationTest {
     @Test
     public void ensureFailingCacheWriteDoesNotPreventFurtherWrites() {
         FailingWriteCache cache = new FailingWriteCache();
-        ConfigJsonCache memoryCache = new ConfigJsonCache(logger, cache, "");
+        ConfigJsonCache memoryCache = new ConfigJsonCache(
+                new ConfigCatLogger(LoggerFactory.getLogger(ConfigCatClientIntegrationTest.class)), cache, "");
 
         Config initialConfig = memoryCache.readFromJson(String.format(TEST_JSON, "initial"), "etag1");
         memoryCache.writeToCache(initialConfig);

--- a/src/test/java/com/configcat/ConfigCatClientTest.java
+++ b/src/test/java/com/configcat/ConfigCatClientTest.java
@@ -248,7 +248,7 @@ public class ConfigCatClientTest {
     }
 
     @Test
-    public void getAllValues() throws IOException, ExecutionException, InterruptedException {
+    public void getAllValues() throws IOException {
         MockWebServer server = new MockWebServer();
         server.start();
 

--- a/src/test/java/com/configcat/ConfigFetcherTest.java
+++ b/src/test/java/com/configcat/ConfigFetcherTest.java
@@ -141,37 +141,12 @@ public class ConfigFetcherTest {
     }
 
     @Test
-    public void cacheWriteFails() throws Exception {
-        this.server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON2));
-        ConfigCache cache = mock(ConfigCache.class);
-
-        Gson gson = new GsonBuilder().create();
-        Config config = gson.fromJson(TEST_JSON, Config.class);
-        config.timeStamp = Instant.now().getEpochSecond();
-
-        when(cache.read(anyString())).thenReturn(gson.toJson(config));
-        doThrow(new Exception()).when(cache).write(anyString(), anyString());
-
-        ConfigJsonCache configJsonCache = new ConfigJsonCache(logger, cache, "");
-        ConfigFetcher fetcher = new ConfigFetcher(new OkHttpClient.Builder().build(), logger, configJsonCache,
-                "", this.server.url("/").toString(), false, PollingModes.manualPoll().getPollingIdentifier());
-
-        FetchResponse result = fetcher.fetchAsync().get();
-        configJsonCache.writeToCache(result.config());
-
-        assertEquals("fakeValue2", configJsonCache.readFromCache().entries.get("fakeKey").value.getAsString());
-
-        fetcher.close();
-    }
-
-    @Test
     public void cacheWriteFailsCachedTakesPrecedence() throws Exception {
         this.server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON2));
         ConfigCache cache = mock(ConfigCache.class);
 
         Gson gson = new GsonBuilder().create();
         Config config = gson.fromJson(TEST_JSON, Config.class);
-        config.timeStamp = Instant.now().getEpochSecond() + 50;
 
         when(cache.read(anyString())).thenReturn(gson.toJson(config));
         doThrow(new Exception()).when(cache).write(anyString(), anyString());

--- a/src/test/java/com/configcat/FailingCache.java
+++ b/src/test/java/com/configcat/FailingCache.java
@@ -12,3 +12,4 @@ public class FailingCache extends ConfigCache {
         throw new Exception();
     }
 }
+

--- a/src/test/java/com/configcat/FailingWriteCache.java
+++ b/src/test/java/com/configcat/FailingWriteCache.java
@@ -1,0 +1,26 @@
+package com.configcat;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class FailingWriteCache extends ConfigCache {
+    Map<String, String> map = new HashMap<>();
+    AtomicInteger counter = new AtomicInteger(1);
+    public AtomicInteger successCounter = new AtomicInteger(0);
+
+    @Override
+    protected String read(String key) {
+        return map.get(key);
+    }
+
+    @Override
+    protected void write(String key, String value) throws Exception {
+        if(counter.getAndIncrement() % 2 == 0){
+            throw new Exception();
+        }
+
+        successCounter.incrementAndGet();
+        map.put(key, value);
+    }
+}


### PR DESCRIPTION
### Describe the purpose of your pull request

When the cache write is failed, further write attempts were skipped because the latest ETag was cached in memory.

### Related issues (only if applicable)

#12 

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
