### PR TITLE
Default user

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=7.2.0
+version=7.3.0

--- a/src/main/java/com/configcat/ConfigurationProvider.java
+++ b/src/main/java/com/configcat/ConfigurationProvider.java
@@ -184,4 +184,20 @@ public interface ConfigurationProvider extends Closeable {
      * @return the future which executes the refresh.
      */
     CompletableFuture<Void> forceRefreshAsync();
+
+    /**
+     * Sets defaultUser value.
+     * If no user specified in the following calls {getValue}, {getAllValues}, {getVariationId},
+     * {getAllVariationIds}, {getValueAsync},  {getAllValuesAsync}, {getVariationIdAsync}, {getAllVariationIdsAsync}
+     * the default user value will be used.
+     *
+     * @param defaultUser The new default user.
+     */
+    void setDefaultUser(User defaultUser);
+
+    /**
+     * Set default user value to null.
+     */
+    void clearDefaultUser();
+
 }


### PR DESCRIPTION
### Describe the purpose of your pull request

Added default user option to ConfigCatClient, default user used when no user passed to `getValue` , `getValue`, `getAllValues`, `getVariationId`,  `getAllVariationIds`, `getValueAsync`,  `getAllValuesAsync`, `getVariationIdAsync`, `getAllVariationIdsAsync`.

The default user can be set with the client builder `defaultUser(User)` method or with the `setDeafultUser(User)`.
The default user can be clear with the `clearDefaultUser()` method.

### Related issues (only if applicable)


### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
