### PR TITLE
Read cache upon each setting read

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: zulu
         cache: gradle
         

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=8.3.0
+version=8.4.0

--- a/src/main/java/com/configcat/Constants.java
+++ b/src/main/java/com/configcat/Constants.java
@@ -8,5 +8,5 @@ final class Constants {
     static final String CONFIG_JSON_NAME = "config_v5.json";
     static final String SERIALIZATION_FORMAT_VERSION = "v2";
 
-    static final String VERSION = "8.3.0";
+    static final String VERSION = "8.4.0";
 }

--- a/src/test/java/com/configcat/AutoPollingTest.java
+++ b/src/test/java/com/configcat/AutoPollingTest.java
@@ -17,9 +17,9 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
-public class AutoPollingPolicyTest {
+public class AutoPollingTest {
     private MockWebServer server;
-    private final ConfigCatLogger logger = new ConfigCatLogger(LoggerFactory.getLogger(AutoPollingPolicyTest.class), LogLevel.WARNING);
+    private final ConfigCatLogger logger = new ConfigCatLogger(LoggerFactory.getLogger(AutoPollingTest.class), LogLevel.WARNING);
     private static final String TEST_JSON = "{ f: { fakeKey: { v: %s, p: [] ,r: [] } } }";
 
     @BeforeEach

--- a/src/test/java/com/configcat/Helpers.java
+++ b/src/test/java/com/configcat/Helpers.java
@@ -10,6 +10,12 @@ final class Helpers {
         return entry.serialize();
     }
 
+    static String cacheValueFromConfigJsonWithEtag(String json, String etag) {
+        Config config = Utils.gson.fromJson(json, Config.class);
+        Entry entry = new Entry(config, etag, json, System.currentTimeMillis());
+        return entry.serialize();
+    }
+
     static void waitFor(Supplier<Boolean> predicate) throws InterruptedException {
         waitFor(3000, predicate);
     }

--- a/src/test/java/com/configcat/LazyLoadingTest.java
+++ b/src/test/java/com/configcat/LazyLoadingTest.java
@@ -14,11 +14,10 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-
-public class ManualPollingPolicyTest {
+public class LazyLoadingTest {
     private ConfigService configService;
     private MockWebServer server;
-    private final ConfigCatLogger logger = new ConfigCatLogger(LoggerFactory.getLogger(ManualPollingPolicyTest.class));
+    private final ConfigCatLogger logger = new ConfigCatLogger(LoggerFactory.getLogger(LazyLoadingTest.class));
     private static final String TEST_JSON = "{ f: { fakeKey: { v: %s, p: [] ,r: [] } } }";
 
     @BeforeEach
@@ -26,7 +25,9 @@ public class ManualPollingPolicyTest {
         this.server = new MockWebServer();
         this.server.start();
 
-        PollingMode mode = PollingModes.manualPoll();
+        LazyLoadingMode mode = (LazyLoadingMode) PollingModes
+                .lazyLoad(5);
+
         ConfigFetcher fetcher = new ConfigFetcher(new OkHttpClient.Builder().build(),
                 logger,
                 "",
@@ -45,38 +46,41 @@ public class ManualPollingPolicyTest {
     @Test
     public void get() throws InterruptedException, ExecutionException {
         this.server.enqueue(new MockResponse().setResponseCode(200).setBody(String.format(TEST_JSON, "test")));
-        this.server.enqueue(new MockResponse().setResponseCode(200).setBody(String.format(TEST_JSON, "test2")).setBodyDelay(2, TimeUnit.SECONDS));
+        this.server.enqueue(new MockResponse().setResponseCode(200).setBody(String.format(TEST_JSON, "test2")).setBodyDelay(3, TimeUnit.SECONDS));
 
         //first call
-        this.configService.refresh().get();
         assertEquals("test", this.configService.getSettings().get().settings().get("fakeKey").getValue().getAsString());
 
-        //next call will get the new value
-        this.configService.refresh().get();
+        //wait for cache invalidation
+        Thread.sleep(6000);
+
+        //next call will block until the new value is fetched
         assertEquals("test2", this.configService.getSettings().get().settings().get("fakeKey").getValue().getAsString());
     }
 
     @Test
     public void getCacheFails() throws InterruptedException, ExecutionException {
-        PollingMode mode = PollingModes.manualPoll();
+        PollingMode mode = PollingModes
+                .lazyLoad(5);
         ConfigFetcher fetcher = new ConfigFetcher(new OkHttpClient.Builder().build(),
-                logger,
-                "",
+                logger
+                , "",
                 this.server.url("/").toString(),
                 false,
                 mode.getPollingIdentifier());
-        ConfigService configService = new ConfigService("", fetcher, mode, new FailingCache(), logger, false, new ConfigCatHooks());
+        ConfigService configService1 = new ConfigService("", fetcher, mode, new FailingCache(), logger, false, new ConfigCatHooks());
 
         this.server.enqueue(new MockResponse().setResponseCode(200).setBody(String.format(TEST_JSON, "test")));
-        this.server.enqueue(new MockResponse().setResponseCode(200).setBody(String.format(TEST_JSON, "test2")).setBodyDelay(2, TimeUnit.SECONDS));
+        this.server.enqueue(new MockResponse().setResponseCode(200).setBody(String.format(TEST_JSON, "test2")).setBodyDelay(3, TimeUnit.SECONDS));
 
         //first call
-        configService.refresh().get();
-        assertEquals("test", configService.getSettings().get().settings().get("fakeKey").getValue().getAsString());
+        assertEquals("test", configService1.getSettings().get().settings().get("fakeKey").getValue().getAsString());
 
-        //next call will get the new value
-        configService.refresh().get();
-        assertEquals("test2", configService.getSettings().get().settings().get("fakeKey").getValue().getAsString());
+        //wait for cache invalidation
+        Thread.sleep(6000);
+
+        //next call will block until the new value is fetched
+        assertEquals("test2", configService1.getSettings().get().settings().get("fakeKey").getValue().getAsString());
     }
 
     @Test
@@ -85,40 +89,81 @@ public class ManualPollingPolicyTest {
         this.server.enqueue(new MockResponse().setResponseCode(500));
 
         //first call
-        this.configService.refresh().get();
         assertEquals("test", this.configService.getSettings().get().settings().get("fakeKey").getValue().getAsString());
 
+        //wait for cache invalidation
+        Thread.sleep(6000);
+
         //previous value returned because of the refresh failure
-        this.configService.refresh().get();
         assertEquals("test", this.configService.getSettings().get().settings().get("fakeKey").getValue().getAsString());
     }
 
     @Test
-    void testCache() throws InterruptedException, ExecutionException, IOException {
+    void testCacheExpirationRespectedInTTLCalc() throws InterruptedException, ExecutionException {
         this.server.enqueue(new MockResponse().setResponseCode(200).setBody(String.format(TEST_JSON, "test")));
-        this.server.enqueue(new MockResponse().setResponseCode(200).setBody(String.format(TEST_JSON, "test2")));
 
-        InMemoryCache cache = new InMemoryCache();
-        PollingMode mode = PollingModes.manualPoll();
+        ConfigCache cache = new SingleValueCache(Helpers.cacheValueFromConfigJson(String.format(TEST_JSON, "test")));
+
+        PollingMode mode = PollingModes
+                .lazyLoad(1);
         ConfigFetcher fetcher = new ConfigFetcher(new OkHttpClient.Builder().build(), logger, "", this.server.url("/").toString(), false, mode.getPollingIdentifier());
         ConfigService service = new ConfigService("", fetcher, mode, cache, logger, false, new ConfigCatHooks());
 
-        service.refresh().get();
-        assertEquals("test", service.getSettings().get().settings().get("fakeKey").getValue().getAsString());
+        assertFalse(service.getSettings().get().settings().isEmpty());
+        assertFalse(service.getSettings().get().settings().isEmpty());
 
-        service.refresh().get();
-        assertEquals("test2", service.getSettings().get().settings().get("fakeKey").getValue().getAsString());
+        assertEquals(0, this.server.getRequestCount());
 
-        assertEquals(1, cache.getMap().size());
+        Thread.sleep(1000);
 
-        service.close();
+        assertFalse(service.getSettings().get().settings().isEmpty());
+        assertFalse(service.getSettings().get().settings().isEmpty());
+
+        assertEquals(1, this.server.getRequestCount());
     }
 
     @Test
-    void testEmptyCacheDoesNotInitiateHTTP() throws InterruptedException, ExecutionException {
-        this.server.enqueue(new MockResponse().setResponseCode(200).setBody(String.format(TEST_JSON, "test")));
+    void testCacheExpirationRespectedInTTLCalc304() throws InterruptedException, ExecutionException {
+        this.server.enqueue(new MockResponse().setResponseCode(304).setBody(""));
 
-        assertTrue(this.configService.getSettings().get().settings().isEmpty());
+        ConfigCache cache = new SingleValueCache(Helpers.cacheValueFromConfigJson(String.format(TEST_JSON, "test")));
+
+        PollingMode mode = PollingModes
+                .lazyLoad(1);
+        ConfigFetcher fetcher = new ConfigFetcher(new OkHttpClient.Builder().build(), logger, "", this.server.url("/").toString(), false, mode.getPollingIdentifier());
+        ConfigService service = new ConfigService("", fetcher, mode, cache, logger, false, new ConfigCatHooks());
+
+        assertFalse(service.getSettings().get().settings().isEmpty());
+        assertFalse(service.getSettings().get().settings().isEmpty());
+
+        assertEquals(0, this.server.getRequestCount());
+
+        Thread.sleep(1000);
+
+        assertFalse(service.getSettings().get().settings().isEmpty());
+        assertFalse(service.getSettings().get().settings().isEmpty());
+
+        assertEquals(1, this.server.getRequestCount());
+    }
+
+    @Test
+    void testCacheTTLRespectsExternalCache() throws Exception {
+        this.server.enqueue(new MockResponse().setResponseCode(200).setBody(String.format(TEST_JSON, "test-remote")));
+
+        ConfigCache cache = new SingleValueCache(Helpers.cacheValueFromConfigJsonWithEtag(String.format(TEST_JSON, "test-local"), "etag"));
+
+        PollingMode mode = PollingModes
+                .lazyLoad(1);
+        ConfigFetcher fetcher = new ConfigFetcher(new OkHttpClient.Builder().build(), logger, "", this.server.url("/").toString(), false, mode.getPollingIdentifier());
+        ConfigService service = new ConfigService("", fetcher, mode, cache, logger, false, new ConfigCatHooks());
+
+        assertEquals("test-local", service.getSettings().get().settings().get("fakeKey").getValue().getAsString());
+        assertEquals(0, this.server.getRequestCount());
+        Thread.sleep(1000);
+
+        cache.write("", Helpers.cacheValueFromConfigJsonWithEtag(String.format(TEST_JSON, "test-local2"), "etag2"));
+        assertEquals("test-local2", service.getSettings().get().settings().get("fakeKey").getValue().getAsString());
+
         assertEquals(0, this.server.getRequestCount());
     }
 
@@ -127,7 +172,7 @@ public class ManualPollingPolicyTest {
         this.server.enqueue(new MockResponse().setResponseCode(200).setBody(String.format(TEST_JSON, "test")));
         this.server.enqueue(new MockResponse().setResponseCode(200).setBody(String.format(TEST_JSON, "test")));
 
-        PollingMode pollingMode = PollingModes.manualPoll();
+        PollingMode pollingMode = PollingModes.lazyLoad(1);
         ConfigFetcher fetcher = new ConfigFetcher(new OkHttpClient(),
                 logger,
                 "",
@@ -136,20 +181,21 @@ public class ManualPollingPolicyTest {
                 pollingMode.getPollingIdentifier());
         ConfigService service = new ConfigService("", fetcher, pollingMode, new NullConfigCache(), logger, false, new ConfigCatHooks());
 
-        assertFalse(service.isOffline());
-        assertTrue(service.refresh().get().isSuccess());
+        assertFalse(service.getSettings().get().settings().isEmpty());
         assertEquals(1, this.server.getRequestCount());
 
         service.setOffline();
-
         assertTrue(service.isOffline());
-        assertFalse(service.refresh().get().isSuccess());
+
+        Thread.sleep(1500);
+
+        assertFalse(service.getSettings().get().settings().isEmpty());
         assertEquals(1, this.server.getRequestCount());
 
         service.setOnline();
-
         assertFalse(service.isOffline());
-        assertTrue(service.refresh().get().isSuccess());
+
+        assertFalse(service.getSettings().get().settings().isEmpty());
         assertEquals(2, this.server.getRequestCount());
 
         service.close();
@@ -160,7 +206,7 @@ public class ManualPollingPolicyTest {
         this.server.enqueue(new MockResponse().setResponseCode(200).setBody(String.format(TEST_JSON, "test")));
         this.server.enqueue(new MockResponse().setResponseCode(200).setBody(String.format(TEST_JSON, "test")));
 
-        PollingMode pollingMode = PollingModes.manualPoll();
+        PollingMode pollingMode = PollingModes.lazyLoad(1);
         ConfigFetcher fetcher = new ConfigFetcher(new OkHttpClient(),
                 logger,
                 "",
@@ -169,14 +215,18 @@ public class ManualPollingPolicyTest {
                 pollingMode.getPollingIdentifier());
         ConfigService service = new ConfigService("", fetcher, pollingMode, new NullConfigCache(), logger, true, new ConfigCatHooks());
 
-        assertTrue(service.isOffline());
-        assertFalse(service.refresh().get().isSuccess());
+        assertTrue(service.getSettings().get().settings().isEmpty());
+        assertEquals(0, this.server.getRequestCount());
+
+        Thread.sleep(1500);
+
+        assertTrue(service.getSettings().get().settings().isEmpty());
         assertEquals(0, this.server.getRequestCount());
 
         service.setOnline();
         assertFalse(service.isOffline());
 
-        assertTrue(service.refresh().get().isSuccess());
+        assertFalse(service.getSettings().get().settings().isEmpty());
         assertEquals(1, this.server.getRequestCount());
 
         service.close();


### PR DESCRIPTION
### Describe the purpose of your pull request

Before, the cache was read only when the in-memory "cache entry" was expired. This PR changes this behavior to reading the cache always and determining the expiration based on the external cache's TTL.

### Related issues (only if applicable)

n/a

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
