### PR TITLE
Replace synchronization with a ReentrantReadWriteLock in ConfigCatHooks

### DIFF
--- a/src/main/java/com/configcat/ConfigCatHooks.java
+++ b/src/main/java/com/configcat/ConfigCatHooks.java
@@ -3,10 +3,11 @@ package com.configcat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 
 public class ConfigCatHooks {
-    private final Object sync = new Object();
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
     private final List<Consumer<Map<String, Setting>>> onConfigChanged = new ArrayList<>();
     private final List<Runnable> onClientReady = new ArrayList<>();
     private final List<Consumer<EvaluationDetails<Object>>> onFlagEvaluated = new ArrayList<>();
@@ -22,8 +23,11 @@ public class ConfigCatHooks {
      * @param callback the method to call when the event fires.
      */
     public void addOnClientReady(Runnable callback) {
-        synchronized (sync) {
+        lock.writeLock().lock();
+        try {
             this.onClientReady.add(callback);
+        } finally {
+            lock.writeLock().unlock();
         }
     }
 
@@ -34,8 +38,11 @@ public class ConfigCatHooks {
      * @param callback the method to call when the event fires.
      */
     public void addOnConfigChanged(Consumer<Map<String, Setting>> callback) {
-        synchronized (sync) {
+        lock.writeLock().lock();
+        try {
             this.onConfigChanged.add(callback);
+        } finally {
+            lock.writeLock().unlock();
         }
     }
 
@@ -45,8 +52,11 @@ public class ConfigCatHooks {
      * @param callback the method to call when the event fires.
      */
     public void addOnError(Consumer<String> callback) {
-        synchronized (sync) {
+        lock.writeLock().lock();
+        try {
             this.onError.add(callback);
+        } finally {
+            lock.writeLock().unlock();
         }
     }
 
@@ -57,49 +67,67 @@ public class ConfigCatHooks {
      * @param callback the method to call when the event fires.
      */
     public void addOnFlagEvaluated(Consumer<EvaluationDetails<Object>> callback) {
-        synchronized (sync) {
+        lock.writeLock().lock();
+        try {
             this.onFlagEvaluated.add(callback);
+        } finally {
+            lock.writeLock().unlock();
         }
     }
 
     void invokeOnClientReady() {
-        synchronized (sync) {
+        lock.readLock().lock();
+        try {
             for (Runnable func : this.onClientReady) {
                 func.run();
             }
+        } finally {
+            lock.readLock().unlock();
         }
     }
 
     void invokeOnError(String error) {
-        synchronized (sync) {
+        lock.readLock().lock();
+        try {
             for (Consumer<String> func : this.onError) {
                 func.accept(error);
             }
+        } finally {
+            lock.readLock().unlock();
         }
     }
 
     void invokeOnConfigChanged(Map<String, Setting> settingMap) {
-        synchronized (sync) {
+        lock.readLock().lock();
+        try {
             for (Consumer<Map<String, Setting>> func : this.onConfigChanged) {
                 func.accept(settingMap);
             }
+        } finally {
+            lock.readLock().unlock();
         }
     }
 
     void invokeOnFlagEvaluated(EvaluationDetails<Object> evaluationDetails) {
-        synchronized (sync) {
+        lock.readLock().lock();
+        try {
             for (Consumer<EvaluationDetails<Object>> func : this.onFlagEvaluated) {
                 func.accept(evaluationDetails);
             }
+        } finally {
+            lock.readLock().unlock();
         }
     }
 
     void clear() {
-        synchronized (sync) {
+        lock.writeLock().lock();
+        try {
             this.onConfigChanged.clear();
             this.onError.clear();
             this.onFlagEvaluated.clear();
             this.onClientReady.clear();
+        } finally {
+            lock.writeLock().unlock();
         }
     }
 }


### PR DESCRIPTION
The ConfigCat client is thread safe and largely scales evaluations across threads, however, hook executions are all synchronized. This can seriously impact performance if the `onFlagEvaluated` hook(s) performs any significant logic (even small 100s of microseconds) or could cause evaluations to hang if a long running `onConfigChanged` hook is executed. A ReentrantReadWriteLock resolves this by allowing multiple concurrent readers to iterate the hook lists.

### Describe the purpose of your pull request

- Improve evaluation and hook performance

### Other Notes

While this change does improve performance pretty dramatically when using hooks, some effort should be considered to further optimize the locking in `ConfigService.fetchIfOlder` and `ConfigService.processResponse`, which can still result in significant latency spikes when loading new config, especially when remote caches are used, or if the `onConfigChanged` hook(s) contain any significant logic.

It could also make sense in a future library version (since it would be a breaking change) to makes hooks immutable outside of the builder to allow for removing the locks entirely. An implementor could create a mutable wrapper if they needed to modify hooks after the client is created.

### Requirement checklist (only if applicable)

- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
