### PR TITLE
Autopoll cache expiration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=9.4.1
+version=9.4.2

--- a/src/main/java/com/configcat/ConfigService.java
+++ b/src/main/java/com/configcat/ConfigService.java
@@ -82,7 +82,7 @@ public class ConfigService implements Closeable {
     }
 
     private void startPoll(AutoPollingMode autoPollingMode) {
-        long ageThreshold = (long) ((autoPollingMode.getAutoPollRateInSeconds() * 1000L) * 0.7);
+        long ageThreshold = (autoPollingMode.getAutoPollRateInSeconds() * 1000L) - 500;
         this.pollScheduler = Executors.newSingleThreadScheduledExecutor();
         this.pollScheduler.scheduleAtFixedRate(() -> fetchIfOlder(System.currentTimeMillis() - ageThreshold, false),
                 0, autoPollingMode.getAutoPollRateInSeconds(), TimeUnit.SECONDS);

--- a/src/main/java/com/configcat/Constants.java
+++ b/src/main/java/com/configcat/Constants.java
@@ -7,7 +7,7 @@ final class Constants {
     static final long DISTANT_PAST = 0;
     static final String CONFIG_JSON_NAME = "config_v6.json";
     static final String SERIALIZATION_FORMAT_VERSION = "v2";
-    static final String VERSION = "9.4.1";
+    static final String VERSION = "9.4.2";
 
     static final String SDK_KEY_PROXY_PREFIX = "configcat-proxy/";
     static final String SDK_KEY_PREFIX = "configcat-sdk-1";


### PR DESCRIPTION
### Describe the purpose of your pull request

- Auto poll correction time fixed to match other SDKs.

### Related issues (only if applicable)

[Trello link](https://trello.com/c/gnqqRydc/411-auto-poll-eset%C3%A9ben-figyelni-kellene-arra-hogy-az-sdk-csak-akkor-t%C3%B6ltse-le-a-configjson-t-ha-expired-t%C3%A9nyleg-a-cache-%C3%A9s-pl-egy-m%C3%A1)

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
